### PR TITLE
Viewing a tweet thread

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,15 @@ Commands
 
     ⚡ :restart
 
+### Threads
+    
+    ⚡ :thread $xx
+
+### Lists
+    
+    ⚡ :list username/list_name
+    ⚡ :list yugui/ruby-committers
+
 And there are more commands!
 
 Configuration

--- a/lib/earthquake/commands.rb
+++ b/lib/earthquake/commands.rb
@@ -163,5 +163,9 @@ module Earthquake
       end
       puts_items thread
     end
+    
+    command :list do |m|
+      puts_items twitter.list_statuses(*m[1].split('/'))
+    end
   end
 end


### PR DESCRIPTION
I added a command to view a thread of tweet conversations. Seems like it should be a core feature. Or we should may be start a "default plugins" repo?
