### PR TITLE
You can change some parts of colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,14 @@ You can change the directory at launch as below:
 
 Blue is excluded.
 
+And you can change some parts of colors.
+
+    Earthquake.config[:color_info] = 33 # timestamp
+    Earthquake.config[:color_private] = 22 # [P] for protected tweet
+    Earthquake.config[:color_mark] = 33 # $xx
+    Earthquake.config[:color_event] = 42 # delete, follow, unfollow, etc
+    Earthquake.config[:color_url] = [4, 36] # URL. this means Underline(4) and Set color to cyan(36)
+
 Desktop Notifications
 ----
 

--- a/lib/earthquake/ext.rb
+++ b/lib/earthquake/ext.rb
@@ -3,6 +3,24 @@ class String
     "\e[#{codes.join;}m#{self}\e[0m"
   end
 
+  def cn(name)
+    default = {
+      :info    => 90, # timestamp
+      :private => 31, # [P] for protected tweet
+      :mark    => 90, # $xx
+      :event   => 42, # such as delete, favorite, unblock, etc
+      :url     => [4, 36], # URL highlight
+    }
+    color = Earthquake.config["color_#{name}".to_sym] || default[name.to_sym]
+    str = self
+    [color].flatten.each{|color|
+      # for multiple colorize. [4, 36] means underline and cyan
+      # see also: http://pueblo.sourceforge.net/doc/manual/ansi_color_codes.html
+      str = str.c(color)
+    }
+    str
+  end
+
   def u
     gsub(/&(lt|gt|amp|quot|apos);/) do |s|
       case s

--- a/lib/earthquake/output.rb
+++ b/lib/earthquake/output.rb
@@ -61,6 +61,7 @@ module Earthquake
     end
   end
 
+
   init do
     outputs.clear
     output_filters.clear
@@ -91,7 +92,7 @@ module Earthquake
         i.c(color_of($1 || $2))
       end
       text.gsub!(URI.regexp(["http", "https"])) do |i|
-        i.c(4).c(36)
+        i.cn(:url)
       end
 
       if item["_highlights"]
@@ -106,11 +107,11 @@ module Earthquake
       mark = item["_mark"] || ""
 
       status =  [
-                  "#{mark}" + "[#{id}]".c(90),
+                  "#{mark}" + "[#{id}]".cn(:mark),
                   "#{item["user"]["screen_name"].c(color_of(item["user"]["screen_name"]))}:",
                   "#{text}",
-                  (item["user"]["protected"] ? "[P]".c(31) : nil),
-                  info.join(' - ').c(90)
+                  (item["user"]["protected"] ? "[P]".cn(:private) : nil),
+                  info.join(' - ').cn(:info)
                 ].compact.join(" ")
       puts status
     end
@@ -121,11 +122,11 @@ module Earthquake
       # TODO: handle 'list_member_added' and 'list_member_removed'
       case item["event"]
       when "follow", "block", "unblock"
-        puts "[#{item["event"]}]".c(42) + " #{item["source"]["screen_name"]} => #{item["target"]["screen_name"]}"
+        puts "[#{item["event"]}]".cn(:event) + " #{item["source"]["screen_name"]} => #{item["target"]["screen_name"]}"
       when "favorite", "unfavorite"
-        puts "[#{item["event"]}]".c(42) + " #{item["source"]["screen_name"]} => #{item["target"]["screen_name"]} : #{item["target_object"]["text"].u}"
+        puts "[#{item["event"]}]".cn(:event) + " #{item["source"]["screen_name"]} => #{item["target"]["screen_name"]} : #{item["target_object"]["text"].u}"
       when "delete"
-        puts "[deleted]".c(42) + " #{item["delete"]["status"]["id"]}"
+        puts "[deleted]".cn(:event) + " #{item["delete"]["status"]["id"]}"
       else
         if config[:debug]
           ap item


### PR DESCRIPTION
twitterで言ってた、色固定だった部分を変えれるようにするやつですー。お納め下さいませ。

Earthquake.config[:color_info] = 33 # timestamp
Earthquake.config[:color_private] = 22 # [P] for protected tweet
Earthquake.config[:color_mark] = 33 # $xx
Earthquake.config[:color_event] = 42 # delete, follow, unfollow, etc
Earthquake.config[:color_url] = [4, 36] # URL.

:color_url means Underline(4) and Set color to cyan(36).
All :color_xxx option can use this style.
