### PR TITLE
Add :hide_time config option

### DIFF
--- a/lib/earthquake/output.rb
+++ b/lib/earthquake/output.rb
@@ -80,7 +80,9 @@ module Earthquake
       elsif item["retweeted_status"]
         info << "(retweet of #{id2var(item["retweeted_status"]["id"])})"
       end
-      info << Time.parse(item["created_at"]).strftime(config[:time_format])
+      if !config[:hide_time] && item["created_at"]
+        info << Time.parse(item["created_at"]).strftime(config[:time_format])
+      end
       if !config[:hide_app_name] && item["source"]
         info << (item["source"].u =~ />(.*)</ ? $1 : 'web')
       end


### PR DESCRIPTION
This is the same approach as the :hide_app_name config option, but for the created_at field.

Setting :time_format to an empty string was not sufficient because the dash still remains on a reply tweet.

Thanks. Earthquake is great.
