### PR TITLE
make prompt configurable

### DIFF
--- a/lib/earthquake/core.rb
+++ b/lib/earthquake/core.rb
@@ -53,6 +53,7 @@ module Earthquake
       config[:time_format]      ||= Time::DATE_FORMATS[:short]
       config[:plugin_dir]       ||= File.join(config[:dir], 'plugin')
       config[:file]             ||= File.join(config[:dir], 'config')
+      config[:prompt]           ||= '⚡ '
       config[:consumer_key]     ||= 'RmzuwQ5g0SYObMfebIKJag'
       config[:consumer_secret]  ||= 'V98dYYmWm9JoG7qfOF0jhJaVEVW3QhGYcDJ9JQSXU'
 
@@ -89,7 +90,7 @@ module Earthquake
 
       EventMachine::run do
         Thread.start do
-          while buf = Readline.readline("⚡ ", true)
+          while buf = Readline.readline(config[:prompt], true)
             unless Readline::HISTORY.count == 1
               Readline::HISTORY.pop if buf.empty? || Readline::HISTORY[-1] == Readline::HISTORY[-2]
             end


### PR DESCRIPTION
http://twitter.com/jugyo/status/54191759269441536 が素敵なのですが、
http://twitter.com/jugyo/status/54196633050693633 は避けたいので、
プロンプトを設定可能にして、config ファイルに書いちゃうのはどうでしょうか？
手元では、

<pre>
$ tail -n1 ~/.earthquake/config
Earthquake.config[:prompt] = '[no6v] ⚡ '
</pre>


こんな感じで動いてます。:eval でプロンプトの変更とか出来て、ムダにいい感じですw
でも config ファイルの先頭にマジコメが必要になるんですよねー。
