### PR TITLE
take only base 36 characters to calculate the string color

### DIFF
--- a/lib/earthquake/output.rb
+++ b/lib/earthquake/output.rb
@@ -54,7 +54,7 @@ module Earthquake
     end
 
     def color_of(screen_name)
-      config[:colors][screen_name.to_i(36) % config[:colors].size]
+      config[:colors][screen_name.delete("^0-9A-Za-z_").to_i(36) % config[:colors].size]
     end
   end
 


### PR DESCRIPTION
coloring の影響で、@screen_name や #hashtag の色が全部同じになっちゃってますね。
@ や # まで含めて color_of に渡しちゃってるのが原因ですが、
coloring のブロックでは $1 とかは取り出せないので、color_of の方をいじってみました。

36 進数だとすると _ も取った方がいいんでしょうけど、_ で始まる文字列の色が変わっちゃいますね。
