### PR TITLE
特定の環境におけるLoadErrorの問題を直しました

### DIFF
--- a/bin/earthquake
+++ b/bin/earthquake
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 require 'slop'
+require 'pathname'
 
 argv = ARGV.dup
 opts = Slop.parse! argv, :help => true do
@@ -10,7 +11,8 @@ options = opts.to_hash(true)
 options.delete(:help)
 options[:dir] = argv.shift unless argv.empty?
 
-$:.unshift(File.expand_path('../../lib', __FILE__)) if $0 == __FILE__
+TOP = Pathname.new(File.dirname(__FILE__)).realpath + '..'
+$:.unshift((TOP + 'lib').to_s) if $0 == __FILE__
 
 print "\e[31m"
 puts %q{
@@ -20,7 +22,7 @@ puts %q{
 |  __/ (_| | |  | |_| | | | (_| | |_| | (_| |   <  __/
  \___|\__,_|_|   \__|_| |_|\__, |\__,_|\__,_|_|\_\___|
                               |_|           }.
-gsub(/^\n/, '') + "v#{File.read(File.expand_path('../../VERSION', __FILE__))}".rjust(10) + "\n\n"
+gsub(/^\n/, '') + "v#{(TOP + 'VERSION').read}".rjust(10) + "\n\n"
 print "\e[0m"
 
 require 'earthquake'


### PR DESCRIPTION
e.g.:
    $ ~/git/earthquake
    $ ln -s ~/git/earthquake/bin ~/bin.d/earthquake # ~/bin.d/\* is added to $PATH by ~/.bash_profile, ~/.zshenv

上のような環境だとLoadErrorがでます。
- `File.expand_path('../../lib', __FILE__)` は `~/bin.d/lib`
- `File.expand_path('../../VERSION', __FILE__)` は `~/bin.d/VERSION`
  という風になるので、`File.dirname(__FILE__)`中にあるシンボリックリンクを解決するようにしました。
