### PR TITLE
Don't crash on loading history

### DIFF
--- a/lib/earthquake/core.rb
+++ b/lib/earthquake/core.rb
@@ -182,8 +182,14 @@ module Earthquake
 
     def restore_history
       history_file = File.join(config[:dir], 'history')
-      if File.exists?(history_file)
-        File.read(history_file).split(/\n/).each { |line| Readline::HISTORY << line }
+      begin
+        File.read(history_file, :encoding => "BINARY").
+          encode!(:invalid => :replace, :undef => :replace).
+          split(/\n/).
+          each { |line| Readline::HISTORY << line }
+      rescue Errno::ENOENT
+      rescue Errno::EACCES => e
+        error(e)
       end
     end
 


### PR DESCRIPTION
I had accidentally typed some invalid characters on my terminal and on the following run, couldn't load earthquake anymore.

This fixes it by replacing invalid characters in the history. 

(as a side note: Another possibility would have been to split the lines as binary, and then each line should be checked valid and put in the history only if valid)
