### PR TITLE
use a different color for @knsmr from @kdmsnr

### DIFF
--- a/lib/earthquake/output.rb
+++ b/lib/earthquake/output.rb
@@ -57,6 +57,7 @@ module Earthquake
     end
 
     def color_of(screen_name)
+      return config[:colors][(config[:colors].index(color_of('kdmsnr')) + 1) % config[:colors].size] if screen_name == 'knsmr'
       config[:colors][screen_name.delete("^0-9A-Za-z_").to_i(36) % config[:colors].size]
     end
   end


### PR DESCRIPTION
デフォルトの状態だと西村さんも角さんも青で、見分けが付きません。
このパッチはどんな色設定でも必ず西村さんと角さんを別の色で表示します。
また、西村さん以外の人はパッチを当てる前の色のままです。

（冗談なのでmergeしないでくださいｗ）
