### PR TITLE
Fixes deprecation message in browse

### DIFF
--- a/lib/earthquake/core.rb
+++ b/lib/earthquake/core.rb
@@ -227,7 +227,7 @@ module Earthquake
     alias_method :n, :notify
 
     def browse(url)
-      Launchy::Browser.run(url)
+      Launchy.open(url)
     end
   end
 


### PR DESCRIPTION
Launchy's API changed and every call to `browse` resulted in this message:

```
⚡ :open $ax
WARNING: You made a call to a deprecated Launchy API. This call should be changed to 'Launchy.open( uri )'
WARNING: I think I was able to find the location that needs to be fixed. Please go look at:
WARNING: 
WARNING: /Users/lukasz/.rvm/gems/ruby-1.9.2-p290/gems/earthquake-0.7.4/lib/earthquake/core.rb:224:in `browse'
WARNING: 
WARNING:     def browse(url)
WARNING:       Launchy::Browser.run(url)
WARNING:     end
WARNING:   end
WARNING: 
WARNING: If this is not the case, please file a bug. Please file a bug at https://github.com/copiousfreetime/launchy/issues/new
⚡ :recent
```
