### PR TITLE
Add installation note about openssl and readline support in 1.9.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,16 @@ Features
 Install
 ----
 
+You'll need openssl and readline support with your 1.9.2. If you are
+using rvm you can run:
+
+    $ rvm pkg install openssl
+    $ rvm remove 1.9.2
+    $ rvm install 1.9.2 --with-openssl-dir=$HOME/.rvm/usr \
+      --with-readline-dir=$HOME/.rvm/usr
+
+Then install the gem:
+
     $ gem install earthquake
 
 **Ubuntu:** EventMachine needs the package libssl-dev.


### PR DESCRIPTION
This adds additional notes to the installation README about 1.9.2 needing openssl and readline support. I was running into this issue myself until I went through the slideshare to see what was missing.
