### PR TITLE
fix line feed problem in case using long multi-byte characters on readline

### DIFF
--- a/lib/earthquake/input.rb
+++ b/lib/earthquake/input.rb
@@ -79,7 +79,8 @@ module Earthquake
     end
 
     def ask(message)
-      Readline.readline(message, false)
+      print message
+      (STDIN.gets || "").chomp
     end
 
     def async_e(&block)


### PR DESCRIPTION
とりあえず print と gets で実装してみました。
gets は Ctrl+D で nil を返すようなので、その場合は "" を使うようにしています。
#68 はクローズされちゃったみたいなので、あとでリオープンしておきます。
