### PR TITLE
support :filter command to switch API easily

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,17 @@ Commands
     # temporarily(with :status, :recent or :thread etc...)
     ⚡ :aa :status $aa
 
+### Stream Filter Tracking
+
+    # keywords
+    ⚡ :filter keyword earthquakegem twitter
+
+    # users
+    ⚡ :filter user jugyo matsuu
+
+    # return to normal user stream
+    ⚡ :filter off
+
 And more!
 
 Configuration


### PR DESCRIPTION
stream-filter-track の機能をコマンドに切り出して、
API を手軽に切り替えられるようにしてみました。
エラー処理が足りないような気もしますが、いかがでしょうか？
