### PR TITLE
Allow :sh <command>

### DIFF
--- a/lib/earthquake/commands.rb
+++ b/lib/earthquake/commands.rb
@@ -406,6 +406,10 @@ Earthquake.init do
     system ENV["SHELL"] || 'sh'
   end
 
+  command %r|^:sh\s+(.+)$|, :as => :sh do |m|
+    system m[1]
+  end
+
   help :sh, "opens a shell"
 
   command %r|:!(.+)| do |m|


### PR DESCRIPTION
:sh can receive a command to execute instead of opening a shell.