### PR TITLE
return only command candidates if it seems like a command

### DIFF
--- a/lib/earthquake/input.rb
+++ b/lib/earthquake/input.rb
@@ -125,6 +125,7 @@ module Earthquake
     completion do |text|
       regexp = /^#{Regexp.quote(text)}/
       results = (command_names + command_aliases.keys).grep(regexp)
+      next results if text.start_with?(?:) and (Readline.point rescue nil) == text.size
       history = Readline::HISTORY.reverse_each.take(config[:history_size]) | @tweets_for_completion
       history.inject(results){|r, line|
         r | line.split.grep(regexp)


### PR DESCRIPTION
入力の先頭で : で始まる文字列を補完しようとした時はコマンドだけを候補として返すようにしてみました。
これでコマンド名をタイポしても平気です :)。

Readline.point は Readline.line_buffer と同時にサポートされているので多分使えると思いますが、
実装されてないと NotImplementedError になって後置 rescue では拾えないので ext.rb とかで
手当てが必要かもしれません。
