### PR TITLE
allow :plugin_install via "t.co" if it points "gist.github.com"

### DIFF
--- a/lib/earthquake/commands.rb
+++ b/lib/earthquake/commands.rb
@@ -441,7 +441,7 @@ Earthquake.init do
       if confirm("Install to '#{filepath}'?")
         File.open(File.join(config[:plugin_dir], filename), 'w') do |file|
           file << raw
-          file << "\n# #{m[1]}"
+          file << "\n# #{uri}\n"
         end
         reload
       end


### PR DESCRIPTION
I'm not sure this is secure way or not, 
but it would be convenient to install a plugin by copy-n-paste in tweet.
