### PR TITLE
refactoring output :delete proc to handle DM removal properly (fixes #93)

### DIFF
--- a/lib/earthquake/output.rb
+++ b/lib/earthquake/output.rb
@@ -137,9 +137,8 @@ module Earthquake
             next
           end
         when deleted.key?("direct_message")
-          if screen_name = twitter.info["screen_name"]
-            text = "(direct message)"
-          end
+          screen_name = twitter.info["screen_name"]
+          text = "(direct message)"
         end
         puts "%s %s: %s" % ["[delete]".c(:event), screen_name, text]
       end


### PR DESCRIPTION
I'm not sure whether the event (DM-removal) by other is noticed or not.
If it never noticed, it's better to use twitter.info() instead of twitter.show().
Anyway, this does not happen very often.
