### PR TITLE
new command ':message_destroy' to delete a direct message

### DIFF
--- a/lib/earthquake/commands.rb
+++ b/lib/earthquake/commands.rb
@@ -356,6 +356,12 @@ Earthquake.init do
 
   help :message, "sent a direct message"
 
+  command :message_destroy do |m|
+    async_e { twitter.message_destroy(m[1]) } if confirm("delete direct message '#{id2var(m[1])}'")
+  end
+
+  help :message_destroy, "deletes direct message"
+
   command :reconnect do
     reconnect
   end


### PR DESCRIPTION
Now, we can treat the notification of DM-removal, so we can make it happen by ourselves :).
