### PR TITLE
suppress increase of onces

### DIFF
--- a/lib/earthquake/core.rb
+++ b/lib/earthquake/core.rb
@@ -34,6 +34,7 @@ module Earthquake
     def _init
       load_config
       load_plugins
+      onces.clear
       inits.each { |block| class_eval(&block) }
       inits.clear
     end
@@ -88,8 +89,8 @@ module Earthquake
 
     def __init(options)
       config.merge!(options)
-      _init
       _once
+      _init
     end
 
     def invoke(command, options = {})


### PR DESCRIPTION
I found that :eval onces.size is getting bigger and bigger.
So, exchange the order of _init and _once, and clear onces every time.

Another approach:
freezing onces after _once, and ignoring passed block via once if onces is frozen.
Which do you like?

```
diff --git a/lib/earthquake/core.rb b/lib/earthquake/core.rb
index a3a4c7d..4153be3 100644
--- a/lib/earthquake/core.rb
+++ b/lib/earthquake/core.rb
@@ -24,11 +24,13 @@ module Earthquake
     end

     def once(&block)
+      return if onces.frozen?
       onces << block
     end

     def _once
       onces.each { |block| class_eval(&block) }
+      onces.freeze
     end

     def _init
```
