### PR TITLE
expand t.co URLs using tweet entities

### DIFF
--- a/lib/earthquake/core.rb
+++ b/lib/earthquake/core.rb
@@ -60,6 +60,7 @@ module Earthquake
       config[:history_size]     ||= 1000
       config[:api]              ||= { :host => 'userstream.twitter.com', :path => '/2/user.json', :ssl => true }
       config[:confirm_type]     ||= :y
+      config[:expand_url]       ||= false
 
       [config[:dir], config[:plugin_dir]].each do |dir|
         unless File.exists?(dir)

--- a/lib/earthquake/output.rb
+++ b/lib/earthquake/output.rb
@@ -105,6 +105,17 @@ module Earthquake
       text.prepend("\n") if config[:raw_text]
       text = text.coloring(/@[0-9A-Za-z_]+/) { |i| color_of(i) }
       text = text.coloring(/(^#[^\s]+)|(\s+#[^\s]+)/) { |i| color_of(i) }
+      if config[:expand_url]
+        entities = (item["retweeted_status"] && item["truncated"]) ? item["retweeted_status"]["entities"] : item["entities"]
+        if entities
+          entities.values_at("urls", "media").flatten.compact.each do |entity|
+            url, expanded_url = entity.values_at("url", "expanded_url")
+            if url && expanded_url
+              text = text.sub(url, expanded_url)
+            end
+          end
+        end
+      end
       text = text.coloring(URI.regexp(["http", "https"]), :url)
 
       if item["_highlights"]


### PR DESCRIPTION
- New config 'expand_url' to expand URLs or not

If config[:expand_url] is true and "tweet entities" is avaiable, try to expand shorten URLs.
Note that, in some cases, the "urls" entity has "url" but does not have "expanded_url".

PS: In future, I'd like to use entities to colorize screen_names and/or hashtags.
If it is acceptable, add option include_entities=1 to GET request forcibly, and 
use entities in various scenes, like as :status, :recent, :search and so on.
