### PR TITLE
customized colors for names and hashtags (fixes #51)

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,23 @@ You can change the directory at launch by entering a directory as an argument. F
       :url => [4, 34]
     }
 
+### Customized colors for names and hashtags
+
+    # See Earthquake.config[:color] for available color names.
+    # Only which looks like a color name is the name of the color :).
+
+    ⚡ :eval config[:color]
+
+    # Colors also can be specified by a single number.
+    # Using colors for background (ex. 44) will not work well on search results.
+
+    # ~/.earthquake/config
+    Earthquake.config[:name_colors] = {
+      earthquakegem: :darkpurple,
+      jugyo: 31,
+      no6v: 44, # it's ok for me to mark my tweet
+    }
+
 ### Tracking specified keywords
 
     # ~/.earthquake/config

--- a/lib/earthquake/output.rb
+++ b/lib/earthquake/output.rb
@@ -64,7 +64,12 @@ module Earthquake
     end
 
     def color_of(screen_name)
-      config[:colors][screen_name.delete("^0-9A-Za-z_").to_i(36) % config[:colors].size]
+      name = screen_name.delete("^0-9A-Za-z_")
+      if color = config[:name_colors][name.to_sym]
+        config[:color][color] || color
+      else
+        config[:colors][name.to_i(36) % config[:colors].size]
+      end
     end
   end
 
@@ -75,11 +80,24 @@ module Earthquake
     config[:colors] ||= (31..36).to_a + (91..96).to_a
     config[:color] ||= {}
     config[:color].reverse_merge!(
+      :darkred    => 31,
+      :darkgreen  => 32,
+      :darkyellow => 33,
+      :darkblue   => 34,
+      :darkpurple => 35,
+      :darkcyan   => 36,
+      :red    => 91,
+      :green  => 92,
+      :yellow => 93,
+      :blue   => 94,
+      :purple => 95,
+      :cyan   => 96,
       :info   => 90,
       :notice => 31,
       :event  => 42,
       :url    => [4, 36]
     )
+    config[:name_colors] ||= {}
     config[:raw_text] ||= false
 
     output :tweet do |item|


### PR DESCRIPTION
I feel the following problems are there in this patch:
- keys must be a Symbol and case-sensitive
- cannot use combined color (ex. [36, 4] like :url)
