### PR TITLE
fix boot problem with slop v3

### DIFF
--- a/bin/earthquake
+++ b/bin/earthquake
@@ -14,7 +14,7 @@ rescue => e
   puts e
   exit!
 end
-options = slop.to_hash(true)
+options = slop.to_hash
 options.delete(:help)
 options[:dir] = argv.shift unless argv.empty?
 


### PR DESCRIPTION
I can't boot earthquake.gem with slop v3.0.2.
I get following error log. 

```
/Users/takkaw/.rvm/gems/ruby-1.9.3-p0/gems/slop-3.0.2/lib/slop.rb:228:in `to_hash': wrong number of arguments (1 for 0) (ArgumentError)
```

The arity of "to_hash" method is changed from one to zero in slop v3.
So, I delete argument in earthquake. 
