### PR TITLE
new configuration for :thread command config[:thread_indent]

### DIFF
--- a/lib/earthquake/commands.rb
+++ b/lib/earthquake/commands.rb
@@ -378,7 +378,7 @@ Earthquake.init do
     end
     print "\e[2K\e[0G"
     puts_items thread.reverse_each.with_index{|tweet, indent|
-      tweet["_mark"] = "  " * indent
+      tweet["_mark"] = config[:thread_indent] * indent
     }
   end
 

--- a/lib/earthquake/core.rb
+++ b/lib/earthquake/core.rb
@@ -62,6 +62,7 @@ module Earthquake
       config[:api]              ||= { :host => 'userstream.twitter.com', :path => '/2/user.json', :ssl => true }
       config[:confirm_type]     ||= :y
       config[:expand_url]       ||= false
+      config[:thread_indent]    ||= "  "
 
       [config[:dir], config[:plugin_dir]].each do |dir|
         unless File.exists?(dir)


### PR DESCRIPTION
Current default (two spaces) is a bit long sometimes for me.

```
⚡ :eval config[:thread_indent] = ""
⚡ :thread $ab
|[$aa] ... vertical
|[$ab] ...
⚡ :eval config[:thread_indent] = nil # or
⚡ :eval config.delete(:thread_indent)
⚡ :thread $ad
|[$ac] ... reset to default
|  [$ad] ...
⚡ :eval config[:thread_indent] = Rational(1, 3)
⚡ :thread $af
|0/1[$ae] ... object responds `*' and accept single integer argument
|1/3[$af] ... this example doesn't make sense... it's your turn now :)
```

Enjoy!

PS: Should I write something in README or help text?
