### PR TITLE
Set initial config perms 0600, it holds secrets

### DIFF
--- a/lib/earthquake/core.rb
+++ b/lib/earthquake/core.rb
@@ -85,7 +85,7 @@ module Earthquake
       if File.exists?(config[:file])
         load config[:file]
       else
-        File.open(config[:file], 'w', 0600)
+        File.open(config[:file], mode: 'w', perm: 0600).close
       end
 
       config.update(preferred_config) do |key, cur, new|


### PR DESCRIPTION
Since the config file holds secret keys for oauth, I figured it was best written default the first time with 0600 perms.
