### PR TITLE
support screen name with at mark in :message command

### DIFF
--- a/lib/earthquake/commands.rb
+++ b/lib/earthquake/commands.rb
@@ -395,7 +395,7 @@ Earthquake.init do
 
   help :sent_messages, "list direct messages sent"
 
-  command %r|^:message (\w+)\s+(.*)|, :as => :message do |m|
+  command %r|^:message @?(\w+)\s+(.*)|, :as => :message do |m|
     async_e { twitter.message(*m[1, 2]) } if confirm("message '#{m[2]}' to @#{m[1]}")
   end
 


### PR DESCRIPTION
I want to write screen name with at mark in :message command(e.g. :message @takkaw hello).
