### PR TITLE
support screen name with at mark in :recent command for private account

### DIFF
--- a/lib/earthquake/commands.rb
+++ b/lib/earthquake/commands.rb
@@ -218,7 +218,7 @@ Earthquake.init do
   end
 
   # :recent jugyo
-  command %r|^:recent\s+([^\/\s]+)$|, :as => :recent do |m|
+  command %r|^:recent\s+@?([^\/\s]+)$|, :as => :recent do |m|
     puts_items twitter.user_timeline(:screen_name => m[1])
   end
 


### PR DESCRIPTION
I want to write screen name with at mark in :recent command(e.g. :recent @takkaw).
Mostly it works, but it doesn't if it's private account. 
