### PR TITLE
Refrains from getting gist API twice.

### DIFF
--- a/lib/earthquake/commands.rb
+++ b/lib/earthquake/commands.rb
@@ -482,7 +482,7 @@ Earthquake.init do
       gist_id = uri.path[/\d+/]
       meta = JSON.parse(open("https://api.github.com/gists/#{gist_id}").read)
       filename = meta["files"].keys[0]
-      raw = open("https://gist.github.com/raw/#{gist_id}/#{filename}").read
+      raw = meta['files'][filename]['content']
 
       puts '-' * 80
       puts raw.c(36)


### PR DESCRIPTION
As the json that Gist API v3 returns contains raw code in itself, now we don't need to access API twice.

``` ruby
pry(main)> json = JSON.parse(open('https://api.github.com/gists/896054').read)
pry(main)> puts json['files'][json['files'].keys[0]]['content']
# -*- coding: utf-8 -*-
# https://twitter.com/#!/jugyo/status/51959560084275200
Earthquake.init do
  t = {
    "u"    => ":update",
    "re"   => ":reply",
    "rt"   => ":retweet",
    "l"    => ":recent",
    "show" => ":status",
  }
  input_filter do |text|
    text.tap do
      if m = %r|^(#{Regexp.union(t.keys)})(\s+.*)?$|o.match(text)
        warn("⚡⚡⚡ Hmm, you are a well-trained termtter user :-(.".c(:notice))
        warn("⚡⚡⚡ Use '#{t[m[1]]}' instead of '#{m[1]}' on earthquake.gem.".c(:notice))
        break [t[m[1]], m[2].gsub(/\$\w+/){|var| var2id(var) || var}].join
      end
    end
  end
end
nil
```
