### PR TITLE
Depend on slop 3.0 or above

### DIFF
--- a/bin/earthquake
+++ b/bin/earthquake
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-gem 'slop', '~> 2.0'
 require 'slop'
 
 argv = ARGV.dup
@@ -16,6 +15,13 @@ rescue => e
   exit!
 end
 options = slop.to_hash
+
+# XXX: work around slop's feature (bug?)
+options.each do |key, val|
+  val = val.nil? ? nil : true if key.to_s =~ /^no-/
+  options[key] = val
+end
+
 options.delete(:help)
 options[:dir] = argv.shift unless argv.empty?
 

--- a/earthquake.gemspec
+++ b/earthquake.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "launchy"
   s.add_runtime_dependency "oauth"
   s.add_runtime_dependency "twitter_oauth", "= 0.4.3"
-  s.add_runtime_dependency "slop", "~> 2.0"
+  s.add_runtime_dependency "slop", "~> 3.0"
   s.add_development_dependency "rspec", "~> 2.0"
   s.add_development_dependency "bundler"
 


### PR DESCRIPTION
This PR should fix issue #134, but it is really ugly. The ugly part is to work around a bug in slop. For example, 

``` ruby
opts = Slop.new {on: 'no-logo'}
opts.parse(%w{--no-logo})
opts.to_hash #=> {:"no-logo" => false}
```

I think that this should be true. Maybe, slot 2.x returns true?

Anyway, this command parsing logic should be refactored like discussed in #121.
