### PR TITLE
work around JRuby String.encode! issue

### DIFF
--- a/lib/earthquake/core.rb
+++ b/lib/earthquake/core.rb
@@ -216,7 +216,7 @@ module Earthquake
       history_file = File.join(config[:dir], 'history')
       begin
         File.read(history_file, :encoding => "BINARY").
-          encode!(:invalid => :replace, :undef => :replace).
+          encode(:invalid => :replace, :undef => :replace).
           split(/\n/).
           each { |line| Readline::HISTORY << line }
       rescue Errno::ENOENT


### PR DESCRIPTION
JRuby 1.6.7.2 (Ruby 1.9 mode) seems to have a bug in String.encode!
resulting in Encoding::ConverterNotFoundError being raised, however,
String.encode does not have this problem.

Call String.encode rather than String.encode! to dispel this error.
