### PR TITLE
use twitter-stream's reconnect-on-timeout behaviour

### DIFF
--- a/earthquake.gemspec
+++ b/earthquake.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency "twitter-stream"
+  s.add_runtime_dependency "twitter-stream", "~> 0.1.16"
   s.add_runtime_dependency "notify"
   s.add_runtime_dependency "i18n"
   s.add_runtime_dependency "activesupport"

--- a/lib/earthquake/core.rb
+++ b/lib/earthquake/core.rb
@@ -70,7 +70,6 @@ module Earthquake
         confirm_type:    :y,
         expand_url:      false,
         thread_indent:   "  ",
-        no_data_timeout: 30
       }
     end
 
@@ -142,27 +141,15 @@ module Earthquake
         end
 
         EM.add_periodic_timer(config[:output_interval]) do
-          if @last_data_received_at && Time.now - @last_data_received_at > config[:no_data_timeout]
-            begin
-              reconnect
-            rescue EventMachine::ConnectionError => e
-              # ignore
-            end
-          end
           if Readline.line_buffer.nil? || Readline.line_buffer.empty?
             sync { output }
           end
         end
 
-        reconnect unless options[:'no-stream'] == true
+        start_stream(config[:api]) unless options[:'no-stream'] == true
 
         trap('INT') { stop }
       end
-    end
-
-    def reconnect
-      item_queue.clear
-      start_stream(config[:api])
     end
 
     def start_stream(options)
@@ -178,7 +165,6 @@ module Earthquake
       @stream = ::Twitter::JSONStream.connect(options)
 
       @stream.each_item do |item|
-        @last_data_received_at = Time.now # for reconnect when no data
         item_queue << JSON.parse(item)
       end
 


### PR DESCRIPTION
twitter-stream ~> 0.1.16 takes care of reconnecting when no data has
been received for a while.  With earthquake also doing this, strange
behaviour occurs when twitter-stream 0.1.16 is used.

Update the dependency to twitter-stream ~> 0.1.16 and remove the
reconnect-on-timeout code from Earthquake::Core to restore normal
behaviour.
