### PR TITLE
fixed :open command if retweeted

### DIFF
--- a/lib/earthquake/commands.rb
+++ b/lib/earthquake/commands.rb
@@ -427,7 +427,9 @@ Earthquake.init do
   help :update_profile_image, "updates profile image from local file path"
 
   command %r|^:open\s+(\d+)$|, :as => :open do |m|
-    matches = URI.extract(twitter.status(m[1])["text"],["http", "https"])
+    matches = twitter.status(m[1])['retweeted_status'].nil? ? 
+      URI.extract(twitter.status(m[1])["text"],["http", "https"]) :
+      URI.extract(twitter.status(m[1])['retweeted_status']["text"],["http", "https"]) 
     unless matches.empty?
       matches.each do |match_url|
         browse match_url


### PR DESCRIPTION
公式RT で省略されてしまった urlが :openコマンドで正しくひらけません。
:open http://t.co/t => "リンクが見つかりませんでした。申し訳ありません。"
かわりにretweeted_status.text 内の url を探す。
