### PR TITLE
Initial implementation of identi.ca support.

### DIFF
--- a/earthquake.gemspec
+++ b/earthquake.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "activesupport"
   s.add_runtime_dependency "awesome_print"
   s.add_runtime_dependency "launchy"
-  s.add_runtime_dependency "oauth"
+  s.add_runtime_dependency "oauth", "~> 0.4.6"
   s.add_runtime_dependency "jugyo-twitter_oauth", "= 0.5.0.pre5"
   s.add_runtime_dependency "slop", "~> 3.4.0"
   s.add_development_dependency "rspec", "~> 2.0"

--- a/lib/earthquake.rb
+++ b/lib/earthquake.rb
@@ -27,4 +27,5 @@ Encoding.default_external = Encoding.find('UTF-8')
   help
   commands
   id_var
+  identica
 ).each { |name| require_dependency File.expand_path("../earthquake/#{name}", __FILE__) }

--- a/lib/earthquake/get_access_token.rb
+++ b/lib/earthquake/get_access_token.rb
@@ -4,7 +4,7 @@ module Earthquake
       consumer = OAuth::Consumer.new(
         self.config[:consumer_key],
         self.config[:consumer_secret],
-        :site => 'https://api.twitter.com',
+        :site => config[:site],
         :proxy => ENV['http_proxy']
       )
       request_token = consumer.get_request_token
@@ -16,15 +16,24 @@ module Earthquake
       pin = STDIN.gets.strip
 
       access_token = request_token.get_access_token(:oauth_verifier => pin)
-      config[:token] = access_token.token
-      config[:secret] = access_token.secret
+      if identica?
+        config[:identica_token] = access_token.token
+        config[:identica_secret] = access_token.secret
+      else
+        config[:token] = access_token.token
+        config[:secret] = access_token.secret
+      end
 
       puts "Saving 'token' and 'secret' to '#{config[:file]}'"
       File.open(config[:file], 'a') do |f|
         f << "\n"
-        f << "Earthquake.config[:token] = '#{config[:token]}'"
-        f << "\n"
-        f << "Earthquake.config[:secret] = '#{config[:secret]}'"
+        if identica?
+          f.puts "Earthquake.config[:identica_token] = '#{config[:identica_token]}'"
+          f.puts "Earthquake.config[:identica_secret] = '#{config[:identica_secret]}'"
+        else
+          f.puts "Earthquake.config[:token] = '#{config[:token]}'"
+          f.puts "Earthquake.config[:secret] = '#{config[:secret]}'"
+        end
       end
     end
   end

--- a/lib/earthquake/identica.rb
+++ b/lib/earthquake/identica.rb
@@ -1,0 +1,44 @@
+module Earthquake
+  module Identica
+    def start_polling_identica
+      reload
+      poll_interval = 30
+      initial_items = 3
+      last_id = nil
+      last_message_id = nil
+      initial_messages = 1
+      Thread.start do
+        loop do
+          begin
+            items = if last_id
+                      twitter.home_timeline(:since_id => last_id)
+                    else
+                      twitter.home_timeline(:count => initial_items)
+                    end
+            items.sort_by{|i|i["id"].to_i}.each do |item|
+              last_id = item["id"]
+              item_queue << item
+            end
+            items = if last_message_id
+                      twitter.messages(:since_id => last_message_id)
+                    else
+                      twitter.messages(:count => initial_messages)
+                    end
+            items.sort_by{|i|i["id"].to_i}.each do |item|
+              last_message_id = item["id"]
+              item["user"] = {"screen_name" => item["sender_screen_name"]}
+              item["_disable_cache"] = true
+              item_queue << item
+            end
+          rescue => e
+            error e
+          end
+          sleep poll_interval
+        end
+      end
+    end
+
+  end
+
+  extend Identica
+end

--- a/lib/earthquake/option_parser.rb
+++ b/lib/earthquake/option_parser.rb
@@ -27,6 +27,7 @@ module Earthquake
         s.on :n, :'no-logo', 'No Logo'
         s.on :c, :command, 'Invoke a command and exit', :argument => true
         s.on :'--no-stream', 'No stream mode'
+        s.on :i, :identica, 'enable identi.ca mode'
       end
     end
   end

--- a/lib/earthquake/twitter.rb
+++ b/lib/earthquake/twitter.rb
@@ -5,7 +5,7 @@ module Earthquake
   end
 
   init do
-    @twitter = TwitterOAuth::Client.new(config.slice(:consumer_key, :consumer_secret, :token, :secret, :api_version, :secure))
+    @twitter = TwitterOAuth::Client.new(config.slice(:consumer_key, :consumer_secret, :token, :secret, :api_version, :api_host, :search_host, :secure))
 
     output do |item|
       next if item["text"].nil? || item["_disable_cache"]


### PR DESCRIPTION
- requires oauth ~> 0.4.6 and a monkey-patched twitter_oauth
- implements a polling based approach to feeding new
  statuses to the user, as identi.ca does not have
  a streaming API
- also polls direct messages

There is an open pull request[1] for twitter_oauth that makes the
URLs configurable, but until this is merged and the gem updated, the
monkey-patch will be necessary.

[1] https://github.com/moomerman/twitter_oauth/pull/33
