### PR TITLE
Upgrade to slop 3.4 and remove workaround for slop

### DIFF
--- a/bin/earthquake
+++ b/bin/earthquake
@@ -1,29 +1,14 @@
 #!/usr/bin/env ruby
-require 'slop'
+require 'earthquake/option_parser'
 
-argv = ARGV.dup
-slop = Slop.new(:strict => true, :help => true)
-slop.banner "Usage: earthquake [options] [directory]"
-slop.on :d, :debug, 'Enable debug mode'
-slop.on :n, :'no-logo', 'No Logo'
-slop.on :c, :command, "Invoke a command and exit", true
-slop.on :'--no-stream', "No stream mode"
+option_parser = Earthquake::OptionParser.new(ARGV.dup)
+options = nil
 begin
-  slop.parse!(argv)
+  options = option_parser.parse
 rescue => e
   puts e
   exit!
 end
-options = slop.to_hash
-
-# XXX: work around slop's feature (bug?)
-options.each do |key, val|
-  val = val.nil? ? nil : true if key.to_s =~ /^no-/
-  options[key] = val
-end
-
-options.delete(:help)
-options[:dir] = argv.shift unless argv.empty?
 
 require 'pathname'
 $:.unshift Pathname.new(__FILE__).realpath.join('../../lib') if $0 == __FILE__

--- a/earthquake.gemspec
+++ b/earthquake.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "launchy"
   s.add_runtime_dependency "oauth"
   s.add_runtime_dependency "twitter_oauth", "= 0.4.3"
-  s.add_runtime_dependency "slop", "~> 3.0"
+  s.add_runtime_dependency "slop", "~> 3.4.0"
   s.add_development_dependency "rspec", "~> 2.0"
   s.add_development_dependency "bundler"
 

--- a/lib/earthquake/option_parser.rb
+++ b/lib/earthquake/option_parser.rb
@@ -1,0 +1,31 @@
+# encoding: UTF-8
+require 'slop'
+
+module Earthquake
+  class OptionParser
+    def initialize(argv)
+      @argv = argv
+      @slop = setup_slop
+    end
+
+    def parse
+      @slop.parse!(@argv)
+      options = @slop.to_hash
+      options.delete(:help)
+      options[:dir] = @argv.shift unless @argv.empty?
+      options
+    end
+
+    private
+
+    def setup_slop
+      Slop.new(:strict => true, :help => true).tap do |s|
+        s.banner 'Usage: earthquake [options] [directory]'
+        s.on :d, :debug, 'Enable debug mode'
+        s.on :n, :'no-logo', 'No Logo'
+        s.on :c, :command, 'Invoke a command and exit', :argument => true
+        s.on :'--no-stream', 'No stream mode'
+      end
+    end
+  end
+end

--- a/spec/earthquake_option_parser_spec.rb
+++ b/spec/earthquake_option_parser_spec.rb
@@ -1,0 +1,78 @@
+# encoding: UTF-8
+require 'spec_helper'
+require 'earthquake/option_parser'
+
+describe Earthquake::OptionParser do
+  describe '#parse' do
+    it 'should return an hash' do
+      options = Earthquake::OptionParser.new([]).parse
+    end
+
+    it 'parses debug option' do
+      %w{-d --debug}.each do |opt|
+        options = Earthquake::OptionParser.new([opt]).parse
+        expect(options[:debug]).to be_true
+      end
+    end
+
+    it 'parses no-logo option' do
+      %w{-n --no-logo}.each do |opt|
+        options = Earthquake::OptionParser.new([opt]).parse
+        expect(options[:'no-logo']).to be_true
+      end
+    end
+
+    it 'parses command option' do
+      %w{-c --command}.each do |opt|
+        command = 'dummy'
+        options = Earthquake::OptionParser.new([opt, command]).parse
+        expect(options[:command]).to eq(command)
+      end
+    end
+
+    it 'parses no-stream option' do
+      options = Earthquake::OptionParser.new(['--no-stream']).parse
+      expect(options[:'no-stream']).to be_true
+    end
+
+    def with_test_output_stream(out, &block)
+      old_stdout = $stderr
+      $stderr = out
+      yield
+      out.close
+    ensure
+      $stderr = old_stdout
+    end
+
+    it 'parses help option' do
+      old_stderr = $stderr
+      begin
+        $stderr = out = StringIO.new
+        Earthquake::OptionParser.new(['--help']).parse
+        out.close
+        expect(out.string).to match(/^Usage: /)
+      rescue => e
+        # do nothing
+      ensure
+        $stderr = old_stderr
+      end
+    end
+
+    it 'raises exception for invalid option' do
+      expect {
+        Earthquake::OptionParser.new(['--foo']).parse
+      }.to raise_exception
+    end
+
+    it 'removes help option' do
+      options= Earthquake::OptionParser.new([]).parse
+      expect(options).to_not be_key(:help)
+    end
+
+    it 'adds rest of arguments as :dir' do
+      dir = 'foo'
+      options= Earthquake::OptionParser.new([dir]).parse
+      expect(options[:dir]).to eq(dir)
+    end
+  end
+end

--- a/spec/earthquake_spec.rb
+++ b/spec/earthquake_spec.rb
@@ -1,7 +1,0 @@
-require 'spec_helper'
-
-describe "Earthquake" do
-  it "fails" do
-    fail "hey buddy, you should probably rename this file and start specing for real"
-  end
-end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,10 @@
-require 'rspec'
+# encoding: UTF-8
+require 'rubygems'
+
+require 'bundler'
+Bundler.require
+
+$: << File.expand_path('../../lib', __FILE__)
 require 'earthquake'
 
 RSpec.configure do |config|


### PR DESCRIPTION
As I promised in #135, I upgraded to slop 3.4 and removed workaround for slop.
