### PR TITLE
Bug fixes

### DIFF
--- a/lib/earthquake/core.rb
+++ b/lib/earthquake/core.rb
@@ -132,7 +132,6 @@ module Earthquake
               Readline::HISTORY.pop if buf.empty? || Readline::HISTORY[-1] == Readline::HISTORY[-2]
             end
             sync {
-              reload
               store_history
               input(buf.strip)
             }

--- a/lib/earthquake/ext.rb
+++ b/lib/earthquake/ext.rb
@@ -1,22 +1,3 @@
-module Twitter
-  class JSONStream
-    protected
-    def reconnect_after timeout
-      @reconnect_callback.call(timeout, @reconnect_retries) if @reconnect_callback
-
-      if timeout == 0
-        reconnect @options[:host], @options[:port]
-        start_tls if @options[:ssl]
-      else
-        EM.add_timer(timeout) do
-          reconnect @options[:host], @options[:port]
-          start_tls if @options[:ssl]
-        end
-      end
-    end
-  end
-end
-
 module TwitterOAuth
   class Client
     [:get, :post, :delete].each { |m| public m }

--- a/lib/earthquake/output.rb
+++ b/lib/earthquake/output.rb
@@ -35,7 +35,7 @@ module Earthquake
       [items].flatten.reverse_each do |item|
         next if output_filters.any? { |f| f.call(item) == false }
 
-        if item["text"] && !item["_stream"]
+        if item["text"] && !item["_stream"] and item['_mark'].to_s.length > 0
           item['_mark'] = ' '.c(mark_color) + item['_mark'].to_s
         end
 

--- a/lib/earthquake/output.rb
+++ b/lib/earthquake/output.rb
@@ -84,6 +84,7 @@ module Earthquake
 
     output :tweet do |item|
       next unless item["text"]
+      next if output_filters.any? { |x| !x.call(item) }
 
       info = []
       if item["in_reply_to_status_id"]


### PR DESCRIPTION
Sorry this pull request is a little coarse, it covers what needed to be done to get this plugin to work, which is a minimal bayesian classifier. https://gist.github.com/db708bfb439f3f9f91f3

Basically, I found a couple of major issues:
- Something about EM 1.0 and twitter-stream 0.1.16, and the monkeypatch you made for reconnections is breaking with OS X complaining about ABI incompatibility. My ruby (1.9.3-p374, readline 6.2) is unfortunately stripped making this pretty hard to debug. Either way, removing the patch entirely seems to have resolved it, as this version of the gem runs `start_tls` after the connection is established by way of the standard EM `connection_completed` hook. So, I think we're good given there's not an issue on other platforms.
- There's a reload command that happens every time a line of input is received from the user. This was causing every initializer to run, which was clearing all the output filters, making it virtually impossible to use them. I'm not having issues running without it, but it's possible I overlooked something.
- The tweet output hook did not account for output filters. Probably a few other places this could be done too.

Let me know if you have any questions or need changes made. Thanks for a great tool!
