### PR TITLE
Output.insert should be exclueded

### DIFF
--- a/lib/earthquake/output.rb
+++ b/lib/earthquake/output.rb
@@ -50,17 +50,21 @@ module Earthquake
     end
 
     def insert(*messages)
-      $stdout = StringIO.new
+      @insert_mutex.synchronize do
+        begin
+          $stdout = StringIO.new
 
-      puts messages
-      yield if block_given?
+          puts messages
+          yield if block_given?
 
-      unless $stdout.string.empty?
-        STDOUT.print "\e[0G\e[K#{$stdout.string}"
-        Readline.refresh_line
+          unless $stdout.string.empty?
+            STDOUT.print "\e[0G\e[K#{$stdout.string}"
+            Readline.refresh_line
+          end
+        ensure
+          $stdout = STDOUT
+        end
       end
-    ensure
-      $stdout = STDOUT
     end
 
     def color_of(screen_name)
@@ -69,6 +73,7 @@ module Earthquake
   end
 
   init do
+    @insert_mutex ||= Mutex.new
     outputs.clear
     output_filters.clear
 


### PR DESCRIPTION
$stdout is swaped in Output.insert, but it's a shared data of all threads.
(https://github.com/jugyo/earthquake/blob/master/lib/earthquake/output.rb#L53-L63)
Output.insert may be called from multi-threads at same time.
For example, Core.error calls Output.insert and it's called from Core.async.
https://github.com/jugyo/earthquake/blob/master/lib/earthquake/core.rb#L251-L256
https://github.com/jugyo/earthquake/blob/master/lib/earthquake/core.rb#L245
