### PR TITLE
work around for TypeMismatch error

### DIFF
--- a/lib/earthquake.rb
+++ b/lib/earthquake.rb
@@ -2,6 +2,7 @@
   json
   thread
   readline
+  date
   active_support/core_ext
   active_support/dependencies
   active_support/cache


### PR DESCRIPTION
Work around a TypeMismatchError with Ruby 2.0 and
ActiveSupport 4.0.0 when only requiring core_ext:

/opt/rubies/2.0.0-p247/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:106:in `require': superclass mismatch for class DateTime (TypeError)
    from /opt/rubies/2.0.0-p247/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:106:in`require'
    from /opt/rubies/2.0.0-p247/lib/ruby/2.0.0/date.rb:3:in `<top (required)>'
    from /opt/rubies/2.0.0-p247/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:106:in`require'
    from /opt/rubies/2.0.0-p247/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:106:in `require'
    from /home/jk/.gem/ruby/2.0.0/gems/activesupport-4.0.0/lib/active_support/core_ext/date/calculations.rb:1:in`<top (required)>'
    from /opt/rubies/2.0.0-p247/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:58:in `require'
    from /opt/rubies/2.0.0-p247/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:58:in`require'
    from /home/jk/.gem/ruby/2.0.0/gems/activesupport-4.0.0/lib/active_support/core_ext/date.rb:2:in `<top (required)>'
    from /opt/rubies/2.0.0-p247/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:106:in`require'
    from /opt/rubies/2.0.0-p247/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:106:in `require'
    from /home/jk/.gem/ruby/2.0.0/gems/activesupport-4.0.0/lib/active_support/core_ext.rb:3:in`block in <top (required)>'
    from /home/jk/.gem/ruby/2.0.0/gems/activesupport-4.0.0/lib/active_support/core_ext.rb:1:in `each'
    from /home/jk/.gem/ruby/2.0.0/gems/activesupport-4.0.0/lib/active_support/core_ext.rb:1:in`<top (required)>'
    from /opt/rubies/2.0.0-p247/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:58:in `require'
    from /opt/rubies/2.0.0-p247/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:58:in`require'
    from /home/jk/.gem/ruby/2.0.0/gems/earthquake-1.0.0/lib/earthquake.rb:14:in `block in <top (required)>'
    from /home/jk/.gem/ruby/2.0.0/gems/earthquake-1.0.0/lib/earthquake.rb:14:in`each'
    from /home/jk/.gem/ruby/2.0.0/gems/earthquake-1.0.0/lib/earthquake.rb:14:in `<top (required)>'
    from /opt/rubies/2.0.0-p247/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:58:in`require'
    from /opt/rubies/2.0.0-p247/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:58:in `require'
    from /home/jk/.gem/ruby/2.0.0/gems/earthquake-1.0.0/bin/earthquake:34:in`<top (required)>'
    from /home/jk/.gem/ruby/2.0.0/bin/earthquake:23:in `load'
    from /home/jk/.gem/ruby/2.0.0/bin/earthquake:23:in`<main>'
