### PR TITLE
Add separator option

### DIFF
--- a/lib/earthquake/output.rb
+++ b/lib/earthquake/output.rb
@@ -147,6 +147,20 @@ module Earthquake
                   info.join(' - ').c(:info)
                 ].compact.join(" ")
       puts status
+
+      if config[:separator]
+        unless config[:screen_width]
+          begin
+            require 'curses'
+            screen = Curses.init_screen
+            config[:screen_width] = screen.maxx
+            Curses.close_screen
+          rescue LoadError
+            config[:screen_width] = 72
+          end
+        end
+        puts config[:separator] * config[:screen_width]
+      end
     end
 
     output :delete do |item|


### PR DESCRIPTION
For making easier to read each tweets.

Usage:

``` ruby
Earthquake.config[:separator] = "-"
```

Output example:

```
[$aa] joker1007: tweet1 29 Jul 17:09 - earthquake
------------------------------------------------
[$ab] joker1007: tweet2 29 Jul 17:09 - earthquake
------------------------------------------------
[$ac] joker1007: tweet3 29 Jul 17:09 - earthquake
------------------------------------------------
```
