### PR TITLE
Catch SystemExit in option_parser_spec

### DIFF
--- a/spec/earthquake_option_parser_spec.rb
+++ b/spec/earthquake_option_parser_spec.rb
@@ -51,7 +51,7 @@ describe Earthquake::OptionParser do
         Earthquake::OptionParser.new(['--help']).parse
         out.close
         expect(out.string).to match(/^Usage: /)
-      rescue => e
+      rescue SystemExit => e
         # do nothing
       ensure
         $stderr = old_stderr


### PR DESCRIPTION
`Earthquake::OptionParser.new(['--help']).parse` will raise SystemExit because of [this line](https://github.com/leejarvis/slop/blob/master/lib/slop.rb#L147).
Since `rescue` catches only `StandardError` by default, [L54](https://github.com/jugyo/earthquake/blob/master/spec/earthquake_option_parser_spec.rb#L54) does not catch `SystemExit` and this spec fails.
I fixed it.
