### PR TITLE
need 'require "yaml"' for Ruby 2.1.0p0

### DIFF
--- a/lib/earthquake.rb
+++ b/lib/earthquake.rb
@@ -12,6 +12,7 @@
   launchy
   oauth
   twitter_oauth
+  yaml
 ).each { |lib| require lib }
 
 Thread.abort_on_exception = true


### PR DESCRIPTION
I had an error like this:

```
home/babie/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/earthquake-1.0.0/lib/earthquake/core.rb:57:in `default_config': uninitialized constant Earthquake::Core::YAML (NameError)
    from /home/babie/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/earthquake-1.0.0/lib/earthquake/core.rb:80:in `load_config'
    from /home/babie/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/earthquake-1.0.0/lib/earthquake/core.rb:39:in `_init'
    from /home/babie/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/earthquake-1.0.0/lib/earthquake/core.rb:117:in `__init'
    from /home/babie/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/earthquake-1.0.0/lib/earthquake/core.rb:127:in `start'
    from /home/babie/.rbenv/versions/2.1.0/lib/ruby/gems/2.1.0/gems/earthquake-1.0.0/bin/earthquake:38:in `<top (required)>'
    from /home/babie/.rbenv/versions/2.1.0/bin/earthquake:23:in `load'
    from /home/babie/.rbenv/versions/2.1.0/bin/earthquake:23:in `<main>'
```

So I added this workaround and it work fine.
