### PR TITLE
Added Docker integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+# Based on the Fedora image
+FROM fedora
+
+MAINTAINER "Maciej Lasyk" <maciek@lasyk.info>
+
+# install main packages:
+RUN yum -y update
+RUN yum -y install openssl-devel openssl readline readline-devel gcc gcc-c++ rubygems rubygems-devel ruby ruby-devel
+
+# install earthquake
+RUN gem install earthquake
+
+# set the env:
+RUN useradd -d /home/twitter twitter
+USER twitter 
+ENV HOME /home/twitter
+WORKDIR /home/twitter
+
+CMD ["earthquake"]

--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ Features
 Install
 ----
 
+Quick-installation using Docker (http://docker.io)
+-----
+
+Just clone the repo and:
+
+    $ sudo docker build -t earthquake .
+    $ sudo docker run --rm -i -name earthquake -t earthquake
+
+Normall installation
+-----
 You'll need openssl and readline support with your 1.9.2. If you are
 using rvm you can run:
 


### PR DESCRIPTION
Guys, I created Dockerfile that makes it very easy to install earthquake on most Linux distros using Docker (LXC based lightweight virtualization: http://docker.io). 

Docker image is based on Fedora. You can test this whole integration using attached Dockerfile and with commands that I pushed to README.md / Install section.

I found this method of installation very easy even for noobies :)
