### PR TITLE
fix EventMachine function call sequence

### DIFF
--- a/lib/earthquake/ext.rb
+++ b/lib/earthquake/ext.rb
@@ -5,12 +5,12 @@ module Twitter
       @reconnect_callback.call(timeout, @reconnect_retries) if @reconnect_callback
 
       if timeout == 0
-        reconnect @options[:host], @options[:port]
         start_tls if @options[:ssl]
+        reconnect @options[:host], @options[:port]
       else
         EM.add_timer(timeout) do
-          reconnect @options[:host], @options[:port]
           start_tls if @options[:ssl]
+          reconnect @options[:host], @options[:port]
         end
       end
     rescue EventMachine::ConnectionError => e


### PR DESCRIPTION
`EventMachine` what is used in `twitter-stream` [disallows calling `start_tls` after you start receiving or sending data](https://github.com/eventmachine/eventmachine/issues/76#issuecomment-312842). The official document [describes about it](http://rubydoc.info/gems/eventmachine/1.0.3/EventMachine/Connection#start_tls-instance_method):

> An appropriate place to call #start_tls is in your redefined #post_init method, or in the #connection_completed handler for an outbound connection.

In EventMachine, [`SslBox` is set non-null value when `StartTls` is called](https://github.com/eventmachine/eventmachine/blob/f1a9eadc47c5fd65ea35620574858348eb25788d/ext/ed.cpp#L1144), so next `start_tls` will [calls `SetTlsParms` over Ruby code](https://github.com/eventmachine/eventmachine/blob/master/lib/em/connection.rb#L415) and [it occurs C++ exception what says "call SetTlsParms before calling StartTls"](https://github.com/eventmachine/eventmachine/blob/f1a9eadc47c5fd65ea35620574858348eb25788d/ext/ed.cpp#L1162).

Current earthquake.gem misses correct function call sequence. This is already represented in #118. I just created this Pull Request with commentary from it.

See also: [Google search: "earthquake" "call SetTlsParms before calling StartTls"](https://www.google.com/search?q=%22earthquake%22+%22call+SetTlsParms+before+calling+StartTls%22), [Twitter search: earthquake "call SetTlsParms before calling StartTls"](https://twitter.com/search?q=earthquake%20%22call%20SetTlsParms%20before%20calling%20StartTls%22&src=typd&f=realtime)
