### PR TITLE
Fix uninitialized constant ActiveSupport::Autoload

### DIFF
--- a/lib/earthquake.rb
+++ b/lib/earthquake.rb
@@ -3,6 +3,7 @@
   thread
   readline
   date
+  active_support/dependencies/autoload
   active_support/core_ext
   active_support/dependencies
   active_support/cache


### PR DESCRIPTION
Fix the following error that occured on Ruby 2.1.2 on Ubuntu 14.04 amd64.

```
                 _   _                       _
  ___  __ _ _ __| |_| |__   __ _ _   _  __ _| | _____
 / _ \/ _` | '__| __| '_ \ / _` | | | |/ _` | |/ / _ \
|  __/ (_| | |  | |_| | | | (_| | |_| | (_| |   <  __/
 \___|\__,_|_|   \__|_| |_|\__, |\__,_|\__,_|_|\_\___|
                              |_|               v1.0.1

/home/username/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/activesupport-4.1.1/lib/active_support/number_helper.rb:3:in `<module:NumberHelper>': uninitialized constant ActiveSupport::Autoload (NameError)
        from /home/username/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/activesupport-4.1.1/lib/active_support/number_helper.rb:2:in `<module:ActiveSupport>'
        from /home/username/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/activesupport-4.1.1/lib/active_support/number_helper.rb:1:in `<top (required)>'
        from /home/username/.rbenv/versions/2.1.2/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /home/username/.rbenv/versions/2.1.2/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /home/username/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/activesupport-4.1.1/lib/active_support/core_ext/numeric/conversions.rb:2:in `<top (required)>'
        from /home/username/.rbenv/versions/2.1.2/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /home/username/.rbenv/versions/2.1.2/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /home/username/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/activesupport-4.1.1/lib/active_support/core_ext/numeric.rb:3:in `<top (required)>'
        from /home/username/.rbenv/versions/2.1.2/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /home/username/.rbenv/versions/2.1.2/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /home/username/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/activesupport-4.1.1/lib/active_support/core_ext.rb:2:in `block in <top (required)>'
        from /home/username/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/activesupport-4.1.1/lib/active_support/core_ext.rb:1:in `each'
        from /home/username/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/activesupport-4.1.1/lib/active_support/core_ext.rb:1:in `<top (required)>'
        from /home/username/.rbenv/versions/2.1.2/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:135:in `require'
        from /home/username/.rbenv/versions/2.1.2/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:135:in `rescue in require'
        from /home/username/.rbenv/versions/2.1.2/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:144:in `require'
        from /home/username/earthquake/lib/earthquake.rb:16:in `block in <top (required)>'
        from /home/username/earthquake/lib/earthquake.rb:16:in `each'
        from /home/username/earthquake/lib/earthquake.rb:16:in `<top (required)>'
        from /home/username/.rbenv/versions/2.1.2/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /home/username/.rbenv/versions/2.1.2/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from ./bin/earthquake:34:in `<main>'
```
