### PR TITLE
Update Dockerfile to use command line args and show local time on the timeline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,6 @@ WORKDIR /root/earthquake
 COPY . .
 RUN bundle install
 RUN cp /usr/local/bundle/gems/earthquake-1.0.2/consumer.yml ./
+ARG TZ
+ENV TZ ${TZ:-UTC}
 ENTRYPOINT ["bundle", "exec", "ruby", "./bin/earthquake"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ WORKDIR /root/earthquake
 COPY . .
 RUN bundle install
 RUN cp /usr/local/bundle/gems/earthquake-1.0.2/consumer.yml ./
-CMD ["bundle", "exec", "ruby", "./bin/earthquake"]
+ENTRYPOINT ["bundle", "exec", "ruby", "./bin/earthquake"]

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Quick-installation using Docker (http://docker.io)
 
 Just clone the repo and:
 
-    $ docker build -t earthquake .
+    $ docker build -t earthquake . --build-arg TZ='Asia/Tokyo'
     $ docker run --rm -v $HOME/.earthquake:/root/.earthquake -it earthquake
 
 Launch with options:

--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ Just clone the repo and:
     $ docker build -t earthquake .
     $ docker run --rm -v $HOME/.earthquake:/root/.earthquake -it earthquake
 
+Launch with options:
+
+    $ docker run -v $HOME/.earthquake:/root/.earthquake -it earthquake --no-stream --no-logo
+
 Normall installation
 -----
 You'll need openssl and readline support with your 1.9.2. If you are

--- a/lib/earthquake/output.rb
+++ b/lib/earthquake/output.rb
@@ -102,7 +102,7 @@ module Earthquake
         info << "(retweet of #{id2var(item["retweeted_status"]["id"])})"
       end
       if !config[:hide_time] && item["created_at"]
-        info << Time.parse(item["created_at"]).strftime(config[:time_format])
+        info << item["created_at"].to_time.strftime(config[:time_format])
       end
       if !config[:hide_app_name] && item["source"]
         info << (item["source"].u =~ />(.*)</ ? $1 : 'web')


### PR DESCRIPTION
- Replace `CMD` in Dockerfile with `ENTRYPOINT` so that we can run docker image with command line arguments. For example `--no-stream`, `--command :recent`, etc.
- Add `ARG TZ` and `ENV TZ` to Dockerfile so that time on timeline can be converted to local time using  [`String#to_time(:local)`](https://api.rubyonrails.org/classes/String.html#method-i-to_time).