### PR TITLE
Avoid truncating long tweet caused by Twitter API change

### DIFF
--- a/lib/earthquake/commands.rb
+++ b/lib/earthquake/commands.rb
@@ -215,7 +215,7 @@ Earthquake.init do
   help :unfollow, "unfollow user"
 
   command :recent do
-    puts_items twitter.home_timeline(:count => config[:recent_count])
+    puts_items twitter.home_timeline(:count => config[:recent_count], :tweet_mode => 'extended')
   end
 
   # :recent jugyo

--- a/lib/earthquake/output.rb
+++ b/lib/earthquake/output.rb
@@ -93,7 +93,7 @@ module Earthquake
     config[:raw_text] ||= true
 
     output :tweet do |item|
-      next unless item["text"]
+      next unless item["full_text"] || item["text"]
 
       info = []
       if item["in_reply_to_status_id"]
@@ -110,7 +110,13 @@ module Earthquake
 
       id = id2var(item["id"])
 
-      text = (item["retweeted_status"] ? "RT @#{item["retweeted_status"]["user"]["screen_name"]}: #{item["retweeted_status"]["text"]}" : item["text"]).u
+      text = if item["retweeted_status"]
+               full_text = item["retweeted_status"]["full_text"] || item["retweeted_status"]["text"]
+               "RT @#{item["retweeted_status"]["user"]["screen_name"]}: #{full_text}"
+             else
+               item["full_text"] || item["text"]
+             end.u
+
       if config[:raw_text] && /\n/ =~ text
         text.prepend("\n")
         text.gsub!(/\n/, "\n       " + "|".c(:info))


### PR DESCRIPTION
In Twitter classic web API, long tweets including URIs are truncated to 140 chars. We can get full tweets by using request parameter `tweet_mode=extended` and response `full_text`.

Since I don't know the scope of this change, I made it compatible with `text`.

See also https://developer.twitter.com/en/docs/tweets/tweet-updates.html